### PR TITLE
fix nsm device id

### DIFF
--- a/nsm-driver/nsm.c
+++ b/nsm-driver/nsm.c
@@ -49,7 +49,7 @@ const char *NSM_VQ_NAME = "nsm.vq.0";
 
 /* NSM device ID */
 static const struct virtio_device_id nsm_id_table[] = {
-	{ 0xEC200001, VIRTIO_DEV_ANY_ID },
+	{ 33, VIRTIO_DEV_ANY_ID },
 	{ 0 },
 };
 


### PR DESCRIPTION
The device ID in initial commit was picked up from a wrong branch and
was set at a previous value which is no longer in use. The current ID
(33) reflects the ID assigned in the virtio spec.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
