### PR TITLE
README: Update README to include the use case of the mentioned kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project builds the kernel, nsm driver and bootstrap process for AWS Nitro Enclaves.
 
+The referenced kernel in the 'linux-url' file is an example that can be used for building an enclave image. The kernel corresponding to the enclave image blobs in https://github.com/aws/aws-nitro-enclaves-cli/tree/main/blobs is based on the v4.14 Amazon Linux kernel - https://github.com/amazonlinux/linux/tree/amazon-4.14.y/master; it is different than the kernel mentioned in 'linux-url'.
+
 ### Prerequisites
 
 The kernel download step requires setting up gpg2 with the kernel developer


### PR DESCRIPTION
The referenced kernel in the 'linux-url' file is used as an example for
building an enclave image. It is different than the kernel from the
Nitro Enclaves CLI repository, which is based on the v4.14 Amazon Linux
kernel.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue https://github.com/aws/aws-nitro-enclaves-cli/issues/257*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
