### PR TITLE
init/Makefile: Ignore nonexistent init file on cleanup

### DIFF
--- a/init/Makefile
+++ b/init/Makefile
@@ -22,4 +22,4 @@ init: init.c
 	$(CROSS_COMPILE)strip --strip-all $@
 
 clean:
-	rm init
+	rm -f init


### PR DESCRIPTION
Add the "-f" option to the "rm" command to ignore the case when the
init binary doesn't exist.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
