### PR TITLE
configs: Update microvm kernel configs to the latest kernel version

### DIFF
--- a/configs/microvm-kernel-config-aarch64
+++ b/configs/microvm-kernel-config-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.246-198.474.amzn2.aarch64 Kernel Configuration
+# Linux/arm64 4.14.256-209.484.amzn2.aarch64 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y
@@ -1895,6 +1895,7 @@ CONFIG_AUXDISPLAY=y
 # CONFIG_VFIO is not set
 CONFIG_VIRT_DRIVERS=y
 CONFIG_VMGENID=y
+# CONFIG_NITRO_ENCLAVES is not set
 CONFIG_VIRTIO=y
 
 #

--- a/configs/microvm-kernel-config-x86_64
+++ b/configs/microvm-kernel-config-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 4.14.246-198.474.amzn2.x86_64 Kernel Configuration
+# Linux/x86_64 4.14.256-209.484.amzn2.x86_64 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y


### PR DESCRIPTION
The enclave kernel blobs are updated in the Nitro Enclaves CLI
repository:

https://github.com/aws/aws-nitro-enclaves-cli/tree/main/blobs

Update the microvm kernel configs for aarch64 and x86_64 in the
aws-nitro-enclaves-sdk-bootstrap repository as well.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
