### PR TITLE
Copy kernel config into output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 
 .PHONY: all blobs
 all: blobs
-blobs: $(OUTDIR)/nsm.ko $(OUTDIR)/$(KERN_IMAGE) $(OUTDIR)/init
+blobs: $(OUTDIR)/nsm.ko $(OUTDIR)/$(KERN_IMAGE) $(OUTDIR)/$(KERN_IMAGE).config $(OUTDIR)/init
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
@@ -51,6 +51,9 @@ $(BUILDDIR)/linux: $(BUILDDIR)/linux.tar $(BUILDDIR)/linux.sign
 
 $(BUILDDIR)/linux/.config: $(BUILDDIR)/linux $(CONFIG)
 	make ARCH=$(ARCH) KCONFIG_ALLCONFIG=$$(pwd)/$(CONFIG) -C $(BUILDDIR)/linux allnoconfig
+
+$(OUTDIR)/$(KERN_IMAGE).config: $(BUILDDIR)/linux/.config
+	cp $(BUILDDIR)/linux/.config $(OUTDIR)/$(KERN_IMAGE).config
 
 $(BUILDDIR)/$(KERN_IMAGE): $(BUILDDIR)/linux $(BUILDDIR)/linux/.config
 	make -j$(nprocs) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(BUILDDIR)/linux


### PR DESCRIPTION
*Issue #, if available: #17

*Description of changes:* The `nitro-cli build-enclave` process expects the platform's kernel config to be present in the blobs directory. Copy the as-built config into the output directory for the convenience of end-users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
