### PR TITLE
Upgrade kernel to v4.14.314

### DIFF
--- a/linux-url
+++ b/linux-url
@@ -1,2 +1,2 @@
-https://amazon-source-code-downloads.s3.amazonaws.com/nitro-enclaves/linux-4.14.204.tar.xz
-https://amazon-source-code-downloads.s3.amazonaws.com/nitro-enclaves/linux-4.14.204.tar.sign
+https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.14.314.tar.xz
+https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.14.314.tar.sign


### PR DESCRIPTION
*Issue #, if available:* #19

*Description of changes:* Upgrade kernel to v4.14.314

I understand that the project hosts a mirror of kernel source, so I imagine that the actual fix here will require mirroring the source to the AWS mirror. Might also be worth considering not doing the mirroring, given how few people actually build the NE kernel themselves.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
