### PR TITLE
Properly limit parallelism of the kernel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(OUTDIR)/$(KERN_IMAGE).config: $(BUILDDIR)/linux/.config
 	cp $(BUILDDIR)/linux/.config $(OUTDIR)/$(KERN_IMAGE).config
 
 $(BUILDDIR)/$(KERN_IMAGE): $(BUILDDIR)/linux $(BUILDDIR)/linux/.config
-	make -j$(nprocs) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(BUILDDIR)/linux $(KERN_IMAGE)
+	make -j$(shell nproc) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(BUILDDIR)/linux $(KERN_IMAGE)
 	cp $(BUILDDIR)/linux/arch/$(ARCH)/boot/$(KERN_IMAGE) $@
 
 $(OUTDIR)/$(KERN_IMAGE): $(BUILDDIR)/$(KERN_IMAGE) $(OUTDIR)


### PR DESCRIPTION
*Issue #, if available:* #23

*Description of changes:* Properly limit parallelism of the kernel build. The Makefile currently invokes the kernel build with `make -j$(nprocs)`, but because `$(nprocs)` is unbound this leads to unlimited parallelism.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
