### PR TITLE
Update init.c - off-by-one fix

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -232,7 +232,7 @@ void init_cgroups() {
     }
     for (;;) {
         static const char base_path[] = "/sys/fs/cgroup/";
-        char path[sizeof(base_path) - 1 + 64];
+        char path[sizeof(base_path) - 1 + 65];
         char* name = path + sizeof(base_path) - 1;
         int hier, groups, enabled;
         int r = fscanf(f, "%64s %d %d %d\n", name, &hier, &groups, &enabled);


### PR DESCRIPTION
The `init_cgroups` method has off-by-one bug. The `fscanf` writes nullbyte outside of the `path` buffer if some `name` field in the `/proc/cgroups` file is longer than 64 characters.

The bug can be verified by compiling the init.c with `-fsanitize=address` flag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
