### PR TITLE
Cross compilation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
 blobs
+result
+result-*
 *.o
 *.ko

--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,16 @@
+{ pkgs ? (import ./nixpkgs.nix) { } }:
 let
-  nixpkgs = (import ./nixpkgs.nix) { };
-
-  arch = nixpkgs.stdenv.hostPlatform.uname.processor;
+  arch = pkgs.stdenv.hostPlatform.uname.processor;
 in
 rec {
-  init = nixpkgs.callPackage ./init/init.nix { };
+  init = pkgs.callPackage ./init/init.nix { };
 
-  kernel = nixpkgs.callPackage ./kernel/kernel.nix { };
+  kernel = pkgs.callPackage ./kernel/kernel.nix { };
 
-  linuxkit = nixpkgs.callPackage ./linuxkit/linuxkit.nix { };
+  linuxkit = pkgs.callPackage ./linuxkit/linuxkit.nix { };
 
 
-  all = nixpkgs.runCommandNoCC "enclaves-blobs-${arch}" { } ''
+  all = pkgs.runCommandNoCC "enclaves-blobs-${arch}" { } ''
     mkdir -p $out/${arch}
     cp -r ${init}/* $out/${arch}/
     cp -r ${kernel}/* $out/${arch}/

--- a/default.nix
+++ b/default.nix
@@ -3,11 +3,11 @@ let
   arch = pkgs.stdenv.hostPlatform.uname.processor;
 in
 rec {
-  init = pkgs.callPackage ./init/init.nix { };
+  init = pkgs.pkgsStatic.callPackage ./init/init.nix { };
 
   kernel = pkgs.callPackage ./kernel/kernel.nix { };
 
-  linuxkit = pkgs.callPackage ./linuxkit/linuxkit.nix { };
+  linuxkit = pkgs.pkgsStatic.callPackage ./linuxkit/linuxkit.nix { };
 
 
   all = pkgs.runCommandNoCC "enclaves-blobs-${arch}" { } ''

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,5 @@
 let
-  nixpkgs = import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
-    sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
-  }) { };
+  nixpkgs = (import ./nixpkgs.nix) { };
 
   arch = nixpkgs.stdenv.hostPlatform.uname.processor;
 in

--- a/init/init.nix
+++ b/init/init.nix
@@ -2,19 +2,11 @@
 pkgs.stdenv.mkDerivation rec {
   name = "nitro-enclaves-init";
 
-  nativeBuildInputs = with pkgs.buildPackages; [
-    gcc
-  ];
-
-  buildInputs = with pkgs; [
-    glibc.static
-  ];
-
   src = ./.;
 
   buildPhase = ''
-    ${pkgs.stdenv.cc.targetPrefix}gcc -Wall -Wextra -Werror -O2 -o init init.c -static -static-libgcc -flto
-    ${pkgs.stdenv.cc.targetPrefix}strip --strip-all init
+    $CC -Wall -Wextra -Werror -O2 -o init init.c -flto
+    $STRIP --strip-all init
   '';
 
   installPhase = ''

--- a/init/init.nix
+++ b/init/init.nix
@@ -1,9 +1,4 @@
-{
-  pkgs ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
-    sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
-  }) {}
-}:
+{ pkgs ? (import ../nixpkgs.nix) { } }:
 pkgs.stdenv.mkDerivation rec {
   name = "nitro-enclaves-init";
 

--- a/init/init.nix
+++ b/init/init.nix
@@ -2,16 +2,19 @@
 pkgs.stdenv.mkDerivation rec {
   name = "nitro-enclaves-init";
 
-  nativeBuildInputs = with pkgs; [
+  nativeBuildInputs = with pkgs.buildPackages; [
     gcc
+  ];
+
+  buildInputs = with pkgs; [
     glibc.static
   ];
 
   src = ./.;
 
   buildPhase = ''
-    gcc -Wall -Wextra -Werror -O2 -o init init.c -static -static-libgcc -flto
-    strip --strip-all init
+    ${pkgs.stdenv.cc.targetPrefix}gcc -Wall -Wextra -Werror -O2 -o init init.c -static -static-libgcc -flto
+    ${pkgs.stdenv.cc.targetPrefix}strip --strip-all init
   '';
 
   installPhase = ''

--- a/kernel/kernel.nix
+++ b/kernel/kernel.nix
@@ -34,12 +34,11 @@ pkgs.stdenv.mkDerivation rec {
   version = "6.6.38";
 
   depsBuildBuild = with pkgs.pkgsBuildBuild; [
-    gcc
+    stdenv.cc
   ];
 
   nativeBuildInputs = with pkgs.buildPackages; [
     git
-    gcc
     flex
     bison
     elfutils

--- a/kernel/kernel.nix
+++ b/kernel/kernel.nix
@@ -1,9 +1,4 @@
-{
-  pkgs ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
-    sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
-  }) {}
-}:
+{ pkgs ? (import ../nixpkgs.nix) { } }:
 let
   arch = pkgs.stdenv.hostPlatform.uname.processor;
 

--- a/kernel/kernel.nix
+++ b/kernel/kernel.nix
@@ -33,7 +33,11 @@ pkgs.stdenv.mkDerivation rec {
   pname = "nitro-enclaves-kernel";
   version = "6.6.38";
 
-  nativeBuildInputs = with pkgs; [
+  depsBuildBuild = with pkgs.pkgsBuildBuild; [
+    gcc
+  ];
+
+  nativeBuildInputs = with pkgs.buildPackages; [
     git
     gcc
     flex

--- a/kernel/kernel.nix
+++ b/kernel/kernel.nix
@@ -74,7 +74,9 @@ pkgs.stdenv.mkDerivation rec {
     export KBUILD_BUILD_TIMESTAMP="$(date -u -d @$SOURCE_DATE_EPOCH)"
     export KBUILD_BUILD_USER="nixbuild"
     export KBUILD_BUILD_HOST="nixbuilder"
-    make olddefconfig ${kern_image} modules -j "$NIX_BUILD_CORES"
+    make olddefconfig ${kern_image} modules -j "$NIX_BUILD_CORES" \
+      ARCH="${kern_arch}" HOSTCC="$CC_FOR_BUILD" HOSTCXX="$CXX_FOR_BUILD" HOSTAR="$AR_FOR_BUILD" HOSTLD="$LD_FOR_BUILD" \
+      CC="$CC" LD="$LD" OBJCOPY="$OBJCOPY" OBJDUMP="$OBJDUMP" READELF="$READELF" STRIP="$STRIP"
   '';
 
   installPhase = ''

--- a/linuxkit/linuxkit.nix
+++ b/linuxkit/linuxkit.nix
@@ -10,10 +10,6 @@ pkgs.buildGoModule rec {
     sha256 = "sha256-M/M4m/vsvvtSDnNNy8p6x+xpv1QmVzyfPRf/BNBX7zA=";
   };
 
-  buildInputs = with pkgs; [
-    musl
-  ];
-
   nativeCheckInputs = with pkgs.buildPackages; [
     git
   ];
@@ -27,7 +23,6 @@ pkgs.buildGoModule rec {
     "-w"
     "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version=${version}+"
     "-linkmode external"
-    "-extldflags '-static -L${pkgs.musl}/lib'"
     "--buildmode pie"
   ];
 

--- a/linuxkit/linuxkit.nix
+++ b/linuxkit/linuxkit.nix
@@ -14,7 +14,7 @@ pkgs.buildGoModule rec {
     musl
   ];
 
-  nativeCheckInputs = with pkgs; [
+  nativeCheckInputs = with pkgs.buildPackages; [
     git
   ];
 

--- a/linuxkit/linuxkit.nix
+++ b/linuxkit/linuxkit.nix
@@ -1,9 +1,4 @@
-{
-  pkgs ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
-    sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
-  }) {}
-}:
+{ pkgs ? (import ../nixpkgs.nix) { } }:
 pkgs.buildGoModule rec {
   pname = "linuxkit";
   version = "1.5.2";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,4 @@
+import (fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
+  sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
+})


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap/issues/35

*Description of changes:*

Our Nix setup currently assumes that `buildPlatform == hostPlatform`, making it impossible to do cross-compilation between `x86_64-linux` and `aarch64-linux`.

Refactor the derivations to properly distinguish build and host dependencies, taking them from the appropriate package set. `pkgs` can now be passed to the top-level derivation, allowing it to be instantiated for supported cross-compilation configurations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Testing

I have tested these changes in a Nitro Enclave on a Graviton2 instance by building a new EIF with these artifacts, and confirming that the "Hello Enclaves" example application boots successfully.

I have tested both the native `aarch64-linux` build on Amazon Linux 2023, as well as the cross-compiled build from `x86_64-linux` on Ubuntu 22.04 generated by the following command:

```plain
$ nix-build -A all --arg pkgs '(import ./nixpkgs.nix { }).pkgsCross.aarch64-multiplatform'
/nix/store/gpxqr7gbm3029dwvjc1075692nbzvn1d-enclaves-blobs-aarch64
$ sha256sum result/**/*
6e68cf95686cbeff4484712fa3207581791064ada31c67fc825830793aab6410  result/aarch64/Image
245fc9dd68df5978aa126cddae368c13ccf83acf06a26cadda51cb6a81281c0b  result/aarch64/Image.config
95a121381b409fd5d55bbc9b63dcb69006a4d1a59e4ea804146c44bcb112433f  result/aarch64/init
55788f344d5405e0b8db1e15bf3100141acb8434e25a5584fd2b86986d5d12aa  result/aarch64/linuxkit
2535b8b4e0b8697c33ba3bb64e3ca15360ceea75eb6cfba6ca3d86300c250368  result/aarch64/nsm.ko
```