### PR TITLE
kernel: Add cmdline to the built artifacts

### DIFF
--- a/kernel/cmdline/aarch64.cmdline
+++ b/kernel/cmdline/aarch64.cmdline
@@ -1,0 +1,1 @@
+reboot=k panic=30 pci=off nomodules console=ttyS0 random.trust_cpu=on root=/dev/ram0

--- a/kernel/cmdline/x86_64.cmdline
+++ b/kernel/cmdline/x86_64.cmdline
@@ -1,0 +1,1 @@
+reboot=k panic=30 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd random.trust_cpu=on

--- a/kernel/kernel.nix
+++ b/kernel/kernel.nix
@@ -28,6 +28,15 @@ let
     else
       abort "Unsupported architecture '${arch}'"
     );
+  
+  cmdline_file = (
+    if arch == "aarch64" then
+      ./cmdline/aarch64.cmdline
+    else if arch == "x86_64" then
+      ./cmdline/x86_64.cmdline
+    else
+      abort "Unsupported architecture '${arch}'"
+    );
 in
 pkgs.stdenv.mkDerivation rec {
   pname = "nitro-enclaves-kernel";
@@ -88,6 +97,7 @@ pkgs.stdenv.mkDerivation rec {
     cp arch/${kern_arch}/boot/${kern_image} $out/
     cp drivers/misc/nsm.ko $out/
     cp .config $out/${kern_image}.config
+    cp ${cmdline_file} $out/cmdline
   '';
 
   # The Nitro Enclaves loader on aarch64 loads the target image at the image provided target address.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR adds the kernel command line parameters to the built artifacts for the Nitro Enclaves kernel. Specifically, it includes the `aarch64.cmdline` and `x86_64.cmdline` files.

As discussed with @foersleo , we may need to further investigate whether these parameters should be kept as-is or modified for each architecture.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
