### PR TITLE
Remove unnecessary ENV TARGET in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM nixos/nix:2.21.4 AS build
 ARG TARGET=all
-ENV TARGET=${TARGET}
 
 RUN mkdir /build
 ADD ./ /build/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed unnecessary `ENV` layer for `TARGET`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
